### PR TITLE
Correct multiline string syntax

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 # corrections to run with other jetty applications
 #  create groups and adjust user
 - name: Rundeck | Ensure jetty group exists
-  group:
+  group: >
     name=jetty
     system=yes
   when: ansible_os_family == 'Debian'
@@ -19,7 +19,7 @@
     - groups
 
 - name: Rundeck | Ensure rundeck user is apart of jetty group
-  user:
+  user: >
     name=rundeck
     groups=jetty
     createhome=yes
@@ -43,7 +43,7 @@
 
 # configuration adjustment
 - name: Rundeck | Ensure upstart setgid is set to jetty group
-  lineinfile:
+  lineinfile: >
     dest=/etc/init/rundeckd.conf
     regexp="^setgid "
     line="setgid jetty"
@@ -55,7 +55,7 @@
     - configuration
 
 - name: Rundeck | Ensure server url is configured
-  lineinfile:
+  lineinfile: >
     dest=/etc/rundeck/rundeck-config.properties
     regexp="^grails.serverURL="
     line="grails.serverURL=http://{{ rundeck_domain }}"
@@ -77,7 +77,7 @@
 
 # extras
 - name: download rundeck plugins
-  get_url:
+  get_url: >
     dest=/var/lib/rundeck/libext/{{ item.split('/')|last }}
     url={{ item }}
   with_items: rundeck_plugins

--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -1,6 +1,6 @@
 ---
 - name: Rundeck - MySQL | make server lib directory
-  file:
+  file: >
     group=rundeck
     mode=0655
     owner=rundeck
@@ -12,7 +12,7 @@
     - mysql
 
 - name: Rundeck - MySQL | download jdbc driver
-  get_url:
+  get_url: >
     dest=/tmp/mysql-connector-java-3.0.17-ga.tar.gz
     url="http://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-3.0.17-ga.tar.gz"
   tags:
@@ -32,7 +32,7 @@
 
 - name: Rundeck - MySQL | copy jdbc driver
   command: mv /tmp/mysql-connector-java-3.0.17-ga/mysql-connector-java-3.0.17-ga-bin.jar /var/lib/rundeck/lib/
-  args: 
+  args:
     creates: /var/lib/rundeck/lib/mysql-connector-java-3.0.17-ga-bin.jar
   tags:
     - rundeck
@@ -40,7 +40,7 @@
     - mysql
 
 - name: Rundeck - MySQL | update database connection in configuration
-  lineinfile:
+  lineinfile: >
     dest=/etc/rundeck/rundeck-config.properties
     regexp="^dataSource.url"
     line="dataSource.url=jdbc:mysql://{{ rundeck_database_host }}:{{ rundeck_database_port }}/{{ rundeck_database_name }}"
@@ -52,7 +52,7 @@
     - mysql
 
 - name: Rundeck - MySQL | update database driver in configuration
-  lineinfile:
+  lineinfile: >
     dest=/etc/rundeck/rundeck-config.properties
     regexp="^dataSource.driverClassName"
     line="dataSource.driverClassName=com.mysql.jdbc.Driver"
@@ -64,7 +64,7 @@
     - mysql
 
 - name: Rundeck - MySQL | update database dialect in configuration
-  lineinfile:
+  lineinfile: >
     dest=/etc/rundeck/rundeck-config.properties
     regexp="^dataSource.dialect"
     line="dataSource.dialect=org.hibernate.dialect.MySQLDialect"
@@ -76,7 +76,7 @@
     - mysql
 
 - name: Rundeck - MySQL | update database username in configuration
-  lineinfile:
+  lineinfile: >
     dest=/etc/rundeck/rundeck-config.properties
     regexp="^dataSource.username"
     line="dataSource.username={{ rundeck_database_user }}"
@@ -88,7 +88,7 @@
     - mysql
 
 - name: Rundeck - MySQL | update database password in configuration
-  lineinfile:
+  lineinfile: >
     dest=/etc/rundeck/rundeck-config.properties
     regexp="^dataSource.password"
     line="dataSource.password={{ rundeck_database_pass }}"

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -1,6 +1,6 @@
 ---
 - name: Rundeck - PostgreSQL | make server lib directory
-  file:
+  file: >
     group=rundeck
     mode=0655
     owner=rundeck
@@ -12,7 +12,7 @@
     - postgresql
 
 - name: Rundeck - PostgreSQL | download postgreSQL jdbc driver
-  get_url:
+  get_url: >
     dest=/var/lib/rundeck/lib/postgresql-9.3-1101.jdbc3.jar
     url="http://jdbc.postgresql.org/download/postgresql-9.3-1101.jdbc3.jar"
     group=rundeck
@@ -24,7 +24,7 @@
     - postgresql
 
 - name: Rundeck - PostgreSQL | update database connection in configuration
-  lineinfile:
+  lineinfile: >
     dest=/etc/rundeck/rundeck-config.properties
     regexp="^dataSource.url"
     line="dataSource.url=jdbc:postgresql://{{ rundeck_database_host }}:{{ rundeck_database_port|default('5432') }}/{{ rundeck_database_name }}"
@@ -36,7 +36,7 @@
     - postgresql
 
 - name: Rundeck - PostgreSQL | update database driver in configuration
-  lineinfile:
+  lineinfile: >
     dest=/etc/rundeck/rundeck-config.properties
     regexp="^dataSource.driverClassName"
     line="dataSource.driverClassName=org.postgresql.Driver"
@@ -48,7 +48,7 @@
     - postgresql
 
 - name: Rundeck - PostgreSQL | update database dialect in configuration
-  lineinfile:
+  lineinfile: >
     dest=/etc/rundeck/rundeck-config.properties
     regexp="^dataSource.dialect"
     line="dataSource.dialect=org.hibernate.dialect.PostgreSQLDialect"
@@ -60,7 +60,7 @@
     - postgresql
 
 - name: Rundeck - PostgreSQL | update database username in configuration
-  lineinfile:
+  lineinfile: >
     dest=/etc/rundeck/rundeck-config.properties
     regexp="^dataSource.username"
     line="dataSource.username={{ rundeck_database_user }}"
@@ -72,7 +72,7 @@
     - postgresql
 
 - name: Rundeck - PostgreSQL | update database password in configuration
-  lineinfile:
+  lineinfile: >
     dest=/etc/rundeck/rundeck-config.properties
     regexp="^dataSource.password"
     line="dataSource.password={{ rundeck_database_pass }}"


### PR DESCRIPTION
Avoid breaking syntax highlighting in editors. See http://symfony.com/doc/current/components/yaml/yaml_format.html#strings

There's some inconsistency about usage of YAML dicts and strings for multiline arguments to modules for example:

Arguments to unarchive in dict format

``` yaml
- name: Rundeck - MySQL | unarchive jdbc driver
  unarchive:
    dest: /tmp
    src: /tmp/mysql-connector-java-3.0.17-ga.tar.gz
    copy: no
  tags:
    - rundeck
    - jdbc
    - mysql
```

vs

Arguments to lineinfile in string format

``` yaml
- name: Rundeck - MySQL | update database connection in configuration
  lineinfile: >
    dest=/etc/rundeck/rundeck-config.properties
    regexp="^dataSource.url"
    line="dataSource.url=jdbc:mysql://{{ rundeck_database_host }}:{{ rundeck_database_port }}/{{ rundeck_database_name }}"
  notify:
    - restart rundeck
  tags:
    - rundeck
    - configuration
    - mysql
```

This PR fixes the syntax for the string format versions (by placing the '>' on the line before the string starts), but doesn't go as far as choosing which format to go with over all.
