### PR TITLE
Rundeck SSH directory now always set to proper permissions.

### DIFF
--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -1,13 +1,4 @@
 ---
-# ssh key generation
-- name: Rundeck | Check default .ssh file location
-  stat:
-    path: /var/lib/rundeck/.ssh
-  register: rundeck_ssh_directory
-  tags:
-    - ssh
-    - rundeck
-
 - name: Rundeck | Ensure .ssh directory exists
   file:
     path: /var/lib/rundeck/.ssh
@@ -16,7 +7,9 @@
     group: rundeck
     mode: 0700
   sudo: yes
-  when: rundeck_ssh_directory.stat.exists == False
+  tags:
+    - ssh
+    - rundeck
 
 # ssh key
 - name: generate a ssh key


### PR DESCRIPTION
Previously if the directory existed but permissions or ownership had somehow been changed, they wouldn't be changed to the intended state.