### PR TITLE
Adds the 4440 port to the grails URL so the application resolves in vagrant.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ The following variables can be overridden:
  * `rundeck_users`: A list of dictionaries of name, password ([hashed](http://rundeck.org/docs/administration/authenticating-users.html#propertyfileloginmodule)) and a list of roles (One must be an admin). If empty the default admin is not removed.
  * `rundeck_plugins`: A list of plugin urls that are downloaded and installed into the rundeck libext, default is none.
  * `rundeck_generate_ssh`: True  # automatically generate ssh key, set to False to stop this action.
-
+ * `rundeck_grails_host`: Defaults to the value in 'rundeck_domain'.
+ * `rundeck_grails_port`: Defaults to 4440
 
 ## Dependencies
 This role does not have a hard dependency on any other role to deploy but rundeck does require java to be installed. smola's [ansible-java-role](https://github.com/smola/ansible-java-role) is a good choice with the

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,6 @@ rundeck_plugins: []  # list of plugin urls that are downloaded and installed int
 rundeck_generate_ssh: True  # automatically generate ssh key, set to False to stop this action.
 # OS, kept for backward compatibility, use rundeck_download_path instead.
 temp_dir: /tmp
+# Running this in vagrant or another non-priv container
+rundeck_grails_host: "{{ rundeck_domain }}"
+rundeck_grails_port: 4440

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,7 +58,7 @@
   lineinfile: >
     dest=/etc/rundeck/rundeck-config.properties
     regexp="^grails.serverURL="
-    line="grails.serverURL=http://{{ rundeck_domain }}"
+    line="grails.serverURL=http://{{ rundeck_grails_host }}:{{ rundeck_grails_port }}"
   notify:
     - restart rundeck
   tags:


### PR DESCRIPTION
I updated the bit that updates the rundeck-config.properties to add the default 4440 port as defined in framework.properties. It might be worth fixing up that next -- I'll see if I can find time. In the meantime this fixes issue #10 for the short term.