### PR TITLE
Parametrise server protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Feedback, bug-reports, requests are welcomed and can be done via [github issues]
 
 The following variables can be overridden:
 
- * `rundeck_domain`: Defaults to localhost:4440 but should the host name web application with accessed by.
+ * `rundeck_protocol`: Defaults to http but should be set to the protocol the web application with accessed by.
+ * `rundeck_domain`: Defaults to localhost:4440 but should be set to the host name web application with accessed by.
  * `rundeck_database_type`: Defaults to hsqldb but can be set to postgresql or mysql to use those databases. Users and databases are not automatically created.
  * `rundeck_database_host`: Defaults to localhost and only needs to be set if using an externally hosted database.
  * `rundeck_database_port`: Defaults to None and must be set if using a different database than the default hsqldb.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # Rundeck
 rundeck_download_path: "{{ temp_dir }}"
+rundeck_domain: "http"  # the protocol that the web application is accessed by.
 rundeck_domain: "localhost:4440"  # the domain that the web application is associated with.
 rundeck_database_type: 'hsqldb'
 rundeck_database_host: 'localhost'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,11 +65,22 @@
     - rundeck
     - configuration
 
-- name: Rundeck | Ensure server url is configured
+- name: Rundeck | Ensure server url is configured (rundeck-config.properties)
   lineinfile: >
     dest=/etc/rundeck/rundeck-config.properties
     regexp="^grails.serverURL="
-    line="grails.serverURL=http://{{ rundeck_domain }}"
+    line="grails.serverURL={{ rundeck_protocol }}://{{ rundeck_domain }}"
+  notify:
+    - restart rundeck
+  tags:
+    - rundeck
+    - configuration
+
+- name: Rundeck | Ensure server url is configured (framework.properties)
+  lineinfile: >
+    dest=/etc/rundeck/framework.properties
+    regexp="^framework\.server\.url\s*\=s*"
+    line="framework.server.url = {{ rundeck_protocol }}://{{ rundeck_domain }}"
   notify:
     - restart rundeck
   tags:


### PR DESCRIPTION
This allows setting the property `rundeck_protocol` to switch between `http` and `https`
It also configure the server URL set in `/etc/rundeck/framework.properties`