### PR TITLE
Add simple systemd service unit

### DIFF
--- a/files/systemd/rundeck-start
+++ b/files/systemd/rundeck-start
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd /var/log/rundeck
+source /etc/rundeck/profile
+exec ${JAVA_HOME:-/usr}/bin/java ${RDECK_JVM} -cp ${BOOTSTRAP_CP} com.dtolabs.rundeck.RunServer /var/lib/rundeck ${RDECK_HTTP_PORT}

--- a/files/systemd/rundeckd.service
+++ b/files/systemd/rundeckd.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=The most awesome distributed command dispatching job console
+After=network.target auditd.service
+
+[Service]
+WorkingDirectory=/var/log/rundeck
+User=rundeck
+Group=rundeck
+ExecStart=/usr/bin/rundeck-start
+Restart=on-failure
+Type=simple

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: systemd daemon-reload
+  become: yes
+  command: systemctl daemon-reload
+  when: ansible_service_mgr == 'systemd'
+
 - name: start rundeck
   service: name=rundeckd state=started
 

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -81,6 +81,7 @@
   register: dpkg_result
   become: yes
   notify:
+    - systemd daemon-reload
     - restart rundeck
   tags:
     - rundeck
@@ -103,6 +104,34 @@
     path: /etc/init.d/rundeckd
     state: absent
   when: upstart_config.stat.exists
+  tags:
+    - rundeck
+    - install
+    - packages
+
+- name: Rundeck | add systemd service helper
+  copy:
+    src: systemd/rundeck-start
+    dest: /usr/bin/rundeck-start
+    owner: root
+    group: root
+    mode: 0755
+  when: ansible_service_mgr == 'systemd'
+  tags:
+    - rundeck
+    - install
+    - packages
+
+- name: Rundeck | add systemd service unit
+  copy:
+    src: systemd/rundeckd.service
+    dest: /etc/systemd/system/rundeckd.service
+    owner: root
+    group: root
+    mode: 0644
+  when: ansible_service_mgr == 'systemd'
+  notify:
+    - systemd daemon-reload
   tags:
     - rundeck
     - install

--- a/tests/vagrant-xenial64/Vagrantfile
+++ b/tests/vagrant-xenial64/Vagrantfile
@@ -1,0 +1,44 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+IP_ADDRESS = "33.33.33.68"
+HTTP_PORT  = 8068
+HTTPS_PORT = 8468
+
+PLAYBOOK = ENV['PLAYBOOK'] || 'default_test.yml'
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "ubuntu/xenial64"
+
+  ## identifier
+  config.vm.hostname = "vagrant-ansible-rundeck-xenial64"
+  ## Network
+  config.vm.network "private_network", ip: IP_ADDRESS
+  config.vm.network "forwarded_port", guest: 4440, host: HTTP_PORT  # Web server
+  config.vm.network "forwarded_port", guest: 443, host: HTTPS_PORT # Secure web server
+  ## virtual box specification
+  config.vm.provider "virtualbox" do |v|
+    v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
+    v.customize ["modifyvm", :id, "--memory", 1024]
+  end
+  ## Provision via ansible using the defaults:
+  config.vm.provision "ansible" do |ansible|
+    ansible.extra_vars = {
+      environment: "vagrant",
+      rundeck_domain: "localhost:8068",
+      java_packages: [ "openjdk-8-jre-headless" ]
+    }
+    ansible.groups = {
+      "rundeck-servers" => [ "default" ]
+    }
+    ansible.playbook = "../#{PLAYBOOK}"
+    ansible.host_key_checking = false
+    ansible.verbose = "v"
+    # use ANSIBLE_KEEP_REMOTE_FILES=1 to debug execution
+  end
+end

--- a/tests/vagrant-xenial64/ansible.cfg
+++ b/tests/vagrant-xenial64/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path=../../../


### PR DESCRIPTION
Rundeck does not support systemd yet and doesn't provide service unit in package. Here is a little kludge to workaround this issue until upstream systemd support is added.
I put unit put to /etc/systemd/system/rundeckd.service not to conflict with package-provided unit in future.

Related issues:
https://github.com/rundeck/rundeck/issues/1156