### PR TITLE
Support pre-hashing of passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The following variables can be overridden:
  * `rundeck_database_name`: Defaults to rundeck but allows you to use a different rundeck database name.
  * `rundeck_database_user`: Defaults to rundeck but allows you to use a different username to accesses the rundeck database.
  * `rundeck_database_pass`: Defaults to rundeck but allows you to use a different password for the user access to the rundeck database.
- * `rundeck_users`: A list of dictionaries of name, password ([hashed](http://rundeck.org/docs/administration/authenticating-users.html#propertyfileloginmodule)) and a list of roles (One must be an admin). If empty the default admin is not removed.
+ * `rundeck_users`: A list of dictionaries of name, password, and a list of roles (One must be an admin). If empty the default admin is not removed. The password will be [hashed](http://rundeck.org/docs/administration/authenticating-users.html#propertyfileloginmodule). A pre-hashed password may be supplied using a key of `password_hash` rather than `password`.
  * `rundeck_plugins`: A list of plugin urls that are downloaded and installed into the rundeck libext, default is none.
  * `rundeck_extra_bootstrap`: A list of extra jar urls that are downloaded and installed into the rundeck bootstrap, default is none.
  * `rundeck_generate_ssh`: Automatically generate ssh key, defgault `True` set to `False` to stop this action.

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -4,14 +4,15 @@
     paths: "/var/lib/rundeck/bootstrap/"
     patterns: "^jetty-all-.*.jar$"
     use_regex: True
+  when: rundeck_users|selectattr('password_hash', 'undefined')|list|length > 0
   register: rundeck_jetty_jar
 
 - name: Users | encode users password
   shell: "java -cp {{ rundeck_jetty_jar.files[0].path }} org.eclipse.jetty.util.security.Password {{ item.name }} {{ item.password }} 2>&1 | grep MD5"
   become: True
   register: rundeck_encoded_users
-  when: rundeck_users|length > 0 and rundeck_jetty_jar['matched'] > 0
-  with_items: "{{ rundeck_users }}"
+  when: rundeck_users|selectattr('password_hash', 'undefined')|list|length > 0 and rundeck_jetty_jar['matched'] > 0
+  with_items: "{{ rundeck_users|selectattr('password_hash', 'undefined')|list }}"
   no_log: true
 
 - name: Users | update basic security to have users

--- a/templates/realm.properties.j2
+++ b/templates/realm.properties.j2
@@ -24,6 +24,9 @@
 #
 #@jetty.user.deploy.name@:@jetty.user.deploy.password@,user,deploy
 #@jetty.user.build.name@:@jetty.user.build.password@,user,build
-{% for user in rundeck_encoded_users.results %}
+{% for user in rundeck_users|selectattr('password_hash', 'defined') %}
+{{ user.name }}:{{ user.password_hash }},user,{{ user.roles|join(',') }}
+{% endfor %}
+{% for user in rundeck_encoded_users.results|rejectattr('skipped', 'defined') %}
 {{ user.item.name }}:{{ user.stdout }},user,{{ user.item.roles|join(',') }}
 {% endfor %}


### PR DESCRIPTION
Storing plaintext passwords in the Ansible config can be a security concern. This change adds the ability to specify the output of the password hash function. The playbook skips the hashing task for users with pre-hashed passwords.