### PR TITLE
Fix fatal error when running in --check mode

### DIFF
--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -104,7 +104,7 @@
     dest=/etc/rundeck/rundeck-config.properties
     line="rundeck.projectsStorageType=db"
     state="present"
-  when: rundeck_targeting_version.stdout|version_compare('2.5.0', '>=')
+  when: (rundeck_targeting_version|default({})).stdout|default('2.5.0')|version_compare('2.5.0', '>=')
   notify:
     - restart rundeck
   tags:

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -89,7 +89,7 @@
     dest=/etc/rundeck/rundeck-config.properties
     line="rundeck.projectsStorageType=db"
     state="present"
-  when: rundeck_targeting_version.stdout|version_compare('2.5.0', '>=')
+  when: (rundeck_targeting_version|default({})).stdout|default('2.5.0')|version_compare('2.5.0', '>=')
   notify:
     - restart rundeck
   tags:


### PR DESCRIPTION
When run using --check mode, the shell command that populates the
`rundeck_targeting_version` variable is skipped. This causes the
playbook to abort when it tries to check the version number against a
minimum value, since it's trying to reference an undefined value.