### PR TITLE
Fix typo in Debian install task

### DIFF
--- a/tasks/install_for_debian.yml
+++ b/tasks/install_for_debian.yml
@@ -54,7 +54,7 @@
   apt:
     name: rundeck
     state: present
-  falsetify:
+  notify:
     - systemd daemon-reload
     - restart rundeck
   tags:


### PR DESCRIPTION
A typo was introduced in tasks/install_for_debian.yml when replacing all the occurences of "no" with "false" and thus changing "notify" to "falsetify".

This PR fixes the typo